### PR TITLE
Convert hex color code to int.

### DIFF
--- a/DiscordWebhooks/Embed.php
+++ b/DiscordWebhooks/Embed.php
@@ -41,7 +41,7 @@ class Embed
   }
 
   public function color($color) {
-    $this->color = $color;
+    $this->color = is_int($color) ? $color : hexdec($color);
 
     return $this;
   }


### PR DESCRIPTION
This change will take a (long form) hexadecimal value and convert it to it's integer equivalent for the Embed color.