### PR TITLE
Timestamp missing in toArray()

### DIFF
--- a/DiscordWebhooks/Embed.php
+++ b/DiscordWebhooks/Embed.php
@@ -107,7 +107,8 @@ class Embed
       'color' => $this->color,
       'footer' => $this->footer,
       'image' => $this->image,
-      'thumbnail' => $this->thumbnail,
+      'thumbnail' => $this->thumbnail,      
+      'timestamp' => $this->timestamp,
       'author' => $this->author,
       'fields' => $this->fields,
     ];


### PR DESCRIPTION
The timestamp property is missing in toArray(), causing it to be left out from the webhook request.