### PR TITLE
Add support for uploading files

### DIFF
--- a/DiscordWebhooks/Client.php
+++ b/DiscordWebhooks/Client.php
@@ -65,7 +65,7 @@ class Client
   }
 
   public function clearFiles() {
-    $this->files = [];
+    $this->files = array();
     return $this;
   }
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ $embed->description('This is an embed');
 $webhook->username('Bot')->message('Hello, Human!')->embed($embed)->send();
 ```
 
+Example of sending files:
+```
+$webhook->addFile("/path/to/file")
+        ->addStringFile("Hello World!", "hello_world.txt")
+        ->send();
+```
+
 ## License
 
 The project is MIT licensed. To read the full license, open [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
Is this project still active? I hope so, other alternatives are way too over-engineered.

Adds support for attaching files. Use `addFile` to add a file on disc, or `addStringFile` to create the file programmatically. Also added `clearFiles` to clear the list. Added support to specify mime type, although discord seems to mostly ignore this value.

Added 200 as a valid return code as this is what discord returns when using Content-Type: multipart/form-data.

Finally removed unused variable `$json_result`

Does no file-size checking, as the maximum depends on how boosted the server is.

#1 