### PR TITLE
fix php 7.4 deprecation

### DIFF
--- a/DiscordWebhooks/Embed.php
+++ b/DiscordWebhooks/Embed.php
@@ -41,7 +41,12 @@ class Embed
   }
 
   public function color($color) {
-    $this->color = is_int($color) ? $color : hexdec($color);
+    if (is_int($color)) {
+        $this->color = $color;
+    } else {
+        $hex = preg_replace('/[^0-9A-Fa-f]/', '', $color);
+        $this->color = hexdec($hex);
+    }
 
     return $this;
   }


### PR DESCRIPTION
since php 7.4, they made it so that passing invalid characters on hexdec is deprecated.

``
Deprecated: Invalid characters passed for attempted conversion, these have been ignored in /var/www/OpenSB/vendor/nopjmp/discord-webhooks/DiscordWebhooks/Embed.php on line 44
``

this makes it a little annoying trying to passthrough hex colors with "#" in the start (a la css):

```php
$mbd->title($title)
    ->author($author)
    ->footer($this->footer_text)
    ->color('#0069B4');
```

this pull request fixes that. now i'm not sure if this works on php 5.4 but i don't think anyone should be using that in 2025.